### PR TITLE
fix: use non-deprecated `getLatestBlockhash` method

### DIFF
--- a/js/packages/cli/src/gumdrop-cli.ts
+++ b/js/packages/cli/src/gumdrop-cli.ts
@@ -539,7 +539,7 @@ async function sendTransactionWithRetry(
   const transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    await connection.getRecentBlockhash(commitment)
+    await connection.getLatestBlockhash({ commitment })
   ).blockhash;
 
   transaction.setSigners(

--- a/js/packages/cli/src/helpers/transactions.ts
+++ b/js/packages/cli/src/helpers/transactions.ts
@@ -33,7 +33,7 @@ export const sendTransactionWithRetryWithKeypair = async (
   const transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {

--- a/js/packages/common/package.json
+++ b/js/packages/common/package.json
@@ -37,7 +37,7 @@
     "@solana/wallet-adapter-base": "^0.4.1",
     "@solana/wallet-adapter-react": "^0.7.1",
     "@solana/wallet-adapter-wallets": "^0.6.1",
-    "@solana/web3.js": "^1.21.0",
+    "@solana/web3.js": "^1.32.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -317,7 +317,7 @@ export const sendTransactions = async (
   const unsignedTxns: Transaction[] = [];
 
   if (!block) {
-    block = await connection.getRecentBlockhash(commitment);
+    block = await connection.getLatestBlockhash({ commitment });
   }
 
   for (let i = 0; i < instructionSet.length; i++) {
@@ -411,7 +411,7 @@ export const sendTransaction = async (
   let transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {
@@ -491,7 +491,7 @@ export const sendTransactionWithRetry = async (
   let transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {

--- a/js/packages/common/src/contracts/token.ts
+++ b/js/packages/common/src/contracts/token.ts
@@ -38,7 +38,7 @@ export const mintNFT = async (
   let transaction = new Transaction();
   const signers = [mintAccount, tokenAccount];
   transaction.recentBlockhash = (
-    await connection.getRecentBlockhash('max')
+    await connection.getLatestBlockhash({ commitment: 'max' })
   ).blockhash;
 
   transaction.add(

--- a/js/packages/fair-launch/package.json
+++ b/js/packages/fair-launch/package.json
@@ -13,7 +13,7 @@
     "@solana/wallet-adapter-react": "^0.9.1",
     "@solana/wallet-adapter-react-ui": "^0.1.0",
     "@solana/wallet-adapter-wallets": "^0.7.5",
-    "@solana/web3.js": "^1.24.1",
+    "@solana/web3.js": "^1.32.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/js/packages/fair-launch/src/connection.tsx
+++ b/js/packages/fair-launch/src/connection.tsx
@@ -135,7 +135,7 @@ export const sendTransactions = async (
   const unsignedTxns: Transaction[] = [];
 
   if (!block) {
-    block = await connection.getRecentBlockhash(commitment);
+    block = await connection.getLatestBlockhash({ commitment });
   }
 
   for (let i = 0; i < instructionSet.length; i++) {
@@ -229,7 +229,7 @@ export const sendTransaction = async (
   let transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {
@@ -296,7 +296,7 @@ export const sendTransactionWithRetry = async (
   let transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {

--- a/js/packages/gumdrop/aws/nodejs/package.json
+++ b/js/packages/gumdrop/aws/nodejs/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solana/web3.js": "^1.30.1",
+    "@solana/web3.js": "^1.32.1",
     "bn": "^1.0.5",
     "bs58": "^4.0.1",
     "discord.js": "12.5.3",

--- a/js/packages/gumdrop/package.json
+++ b/js/packages/gumdrop/package.json
@@ -29,7 +29,7 @@
     "@solana/wallet-adapter-base": "0.4.1",
     "@solana/wallet-adapter-react": "^0.7.1",
     "@solana/wallet-adapter-wallets": "^0.6.1",
-    "@solana/web3.js": "^1.24.1",
+    "@solana/web3.js": "^1.32.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/js/packages/gumdrop/src/components/Claim.tsx
+++ b/js/packages/gumdrop/src/components/Claim.tsx
@@ -765,7 +765,8 @@ export const Claim = (
 
     const transaction = new Transaction({
       feePayer: wallet.publicKey,
-      recentBlockhash: (await connection.getRecentBlockhash("singleGossip")).blockhash,
+      recentBlockhash: (await connection.getLatestBlockhash({ commitment: 'singleGossip' }))
+        .blockhash,
     });
 
     const signers = new Set<PublicKey>();

--- a/js/packages/gumdrop/src/contexts/ConnectionContext.tsx
+++ b/js/packages/gumdrop/src/contexts/ConnectionContext.tsx
@@ -200,7 +200,7 @@ export const sendTransactionWithRetry = async (
   let transaction = new Transaction();
   instructions.forEach((instruction) => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {

--- a/js/packages/gumdrop/src/utils/transactions.ts
+++ b/js/packages/gumdrop/src/utils/transactions.ts
@@ -57,7 +57,7 @@ export const sendTransactionWithRetryWithKeypair = async (
   const transaction = new Transaction();
   instructions.forEach(instruction => transaction.add(instruction));
   transaction.recentBlockhash = (
-    block || (await connection.getRecentBlockhash(commitment))
+    block || (await connection.getLatestBlockhash({ commitment }))
   ).blockhash;
 
   if (includesFeePayer) {

--- a/js/packages/web/package.json
+++ b/js/packages/web/package.json
@@ -15,7 +15,7 @@
     "@solana/spl-token-registry": "^0.2.202",
     "@solana/wallet-adapter-base": "^0.4.1",
     "@solana/wallet-adapter-react": "^0.7.1",
-    "@solana/web3.js": "^1.21.0",
+    "@solana/web3.js": "^1.32.1",
     "@welldone-software/why-did-you-render": "^6.0.5",
     "async-sema": "^3.1.1",
     "bn.js": "^5.1.3",

--- a/js/packages/web/src/actions/nft.tsx
+++ b/js/packages/web/src/actions/nft.tsx
@@ -191,7 +191,7 @@ export const mintNFT = async (
   progressCallback(2);
 
   // TODO: enable when using payer account to avoid 2nd popup
-  // const block = await connection.getRecentBlockhash('singleGossip');
+  // const block = await connection.getLatestBlockhash({ commitment: 'singleGossip' });
   // instructions.push(
   //   SystemProgram.transfer({
   //     fromPubkey: wallet.publicKey,

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3067,7 +3067,7 @@
   resolved "https://registry.yarnpkg.com/@blocto/sdk/-/sdk-0.2.12.tgz#b06a50e2274de909d33bd967a87e8c7d8e55a3c8"
   integrity sha512-3lkdj2JEMEOUTW7EpMUiF7yWs6w3qdNpMmzz+USn3QunZSDgY9Qd00EegvXDk/9EXCIpYJ+p2wIDQ3k0YkTECQ==
   dependencies:
-    "@solana/web3.js" "^1.22.0"
+    "@solana/web3.js" "^1.32.1"
     bs58 "^4.0.1"
     buffer "^6.0.3"
     eip1193-provider "^1.0.1"
@@ -6290,7 +6290,7 @@
   integrity sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==
   dependencies:
     "@project-serum/borsh" "^0.2.2"
-    "@solana/web3.js" "^1.17.0"
+    "@solana/web3.js" "^1.32.1"
     base64-js "^1.5.1"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
@@ -6310,7 +6310,7 @@
   integrity sha512-FqBofCi3O0Y4DAhmCA0SaakXXoMvNHLq9cVTZLP2/3R0bLO2+goRw0wTgFiKsRMW2YkNVr9cbMzd/MiukbyXsQ==
   dependencies:
     "@project-serum/borsh" "^0.2.2"
-    "@solana/web3.js" "^1.17.0"
+    "@solana/web3.js" "^1.32.1"
     base64-js "^1.5.1"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
@@ -6330,7 +6330,7 @@
   integrity sha512-vctZHZD5rUP1WXUUaJFdKl+1u0dE+O2+jejmYcb0InAZiwXdGAW8mX47U902voT94PdCr0aNHuyOQ8I75nfinw==
   dependencies:
     "@project-serum/borsh" "^0.2.2"
-    "@solana/web3.js" "^1.17.0"
+    "@solana/web3.js" "^1.32.1"
     base64-js "^1.5.1"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
@@ -6359,7 +6359,7 @@
   dependencies:
     "@project-serum/anchor" "^0.11.1"
     "@solana/spl-token" "^0.1.6"
-    "@solana/web3.js" "^1.21.0"
+    "@solana/web3.js" "^1.32.1"
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
@@ -6506,7 +6506,7 @@
   integrity sha512-NIsa5xU8Fx9nIofM/mmrNI3s472kDBtNdqI6TbhIaVeP/DTYc9m5dkjvG32T1tZdNMv0kvFIpqZ0iAJvvZ/ABg==
   dependencies:
     "@solana/spl-token" "0.1.6"
-    "@solana/web3.js" "^1.21.0"
+    "@solana/web3.js" "^1.32.1"
     bip32 "^2.0.6"
     bn.js "^5.1.3"
     borsh "^0.4.0"
@@ -6532,7 +6532,7 @@
   integrity sha512-fYj+a3w1bqWN6Ibf85XF3h2JkuxevI3Spvqi+mjsNqVUEo2AgxxTZmujNLn/jIzQDNdWkBfF/wYzH5ikcGHmfw==
   dependencies:
     "@babel/runtime" "^7.10.5"
-    "@solana/web3.js" "^1.12.0"
+    "@solana/web3.js" "^1.32.1"
     bn.js "^5.1.0"
     buffer "6.0.3"
     buffer-layout "^1.2.0"
@@ -6544,7 +6544,7 @@
   integrity sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==
   dependencies:
     "@babel/runtime" "^7.10.5"
-    "@solana/web3.js" "^1.21.0"
+    "@solana/web3.js" "^1.32.1"
     bn.js "^5.1.0"
     buffer "6.0.3"
     buffer-layout "^1.2.0"
@@ -6742,46 +6742,6 @@
     "@solana/wallet-adapter-sollet" "^0.5.2"
     "@solana/wallet-adapter-solong" "^0.5.2"
     "@solana/wallet-adapter-torus" "^0.6.2"
-
-"@solana/web3.js@^1.12.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.21.0.tgz#4f98edea38d4cb3ae4d2ea49a050b0ec09508023"
-  integrity sha512-x1NXlF92tEjxuTxS0u4n9JV17UKk0Dn2L+qSWGvKOb4iWhzApDj6wicJsrGdSbGdxnZ7eciQ/SNn3zB4ydUllA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@solana/buffer-layout" "^3.0.0"
-    bn.js "^5.0.0"
-    borsh "^0.4.0"
-    bs58 "^4.0.1"
-    buffer "6.0.1"
-    crypto-hash "^1.2.2"
-    jayson "^3.4.4"
-    js-sha3 "^0.8.0"
-    node-fetch "^2.6.1"
-    rpc-websockets "^7.4.2"
-    secp256k1 "^4.0.2"
-    superstruct "^0.14.2"
-    tweetnacl "^1.0.0"
-
-"@solana/web3.js@^1.22.0", "@solana/web3.js@^1.24.1":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.28.0.tgz#66a2ea14a892d53768ae23798a3f92df982c56fb"
-  integrity sha512-9sCXVVsRNR8MO4Ww3yyTYLXqNmpz7qX0wVeKHpwYtLTzKh3inncGOniYwpYPFRwEo8ivh0Q+c/GM2EnUHOviRg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@solana/buffer-layout" "^3.0.0"
-    bn.js "^5.0.0"
-    borsh "^0.4.0"
-    bs58 "^4.0.1"
-    buffer "6.0.1"
-    cross-fetch "^3.1.4"
-    crypto-hash "^1.2.2"
-    jayson "^3.4.4"
-    js-sha3 "^0.8.0"
-    rpc-websockets "^7.4.2"
-    secp256k1 "^4.0.2"
-    superstruct "^0.14.2"
-    tweetnacl "^1.0.0"
 
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
   version "1.4.2"


### PR DESCRIPTION
This method has been removed in Agave 2.0. Bumped the `@solana/web3.js` requirement to the oldest version that supports `getLatestBlockhash`.